### PR TITLE
Usability Fixes

### DIFF
--- a/basicutils_6x.py
+++ b/basicutils_6x.py
@@ -22,6 +22,7 @@
 import idc
 import struct
 import idautils
+import idaapi
 import re
 
 BADADDR = idc.BADADDR
@@ -202,7 +203,7 @@ def GetCanonicalName(f):
 def NameCanonical(f,mod_name,func_name):
 	n = "%s_%s_%08x" % (mod_name,func_name,f)
 	print "Renaming %s to %s\n" % (idc.GetFunctionName(f),n)
-	idc.MakeName(f,n)
+	idaapi.do_name_anyway(f,n)
 
 #Put function in canonical format when it doesn't have a name, but you know the module name
 def RenameFuncWithAddr(f,s):

--- a/basicutils_7x.py
+++ b/basicutils_7x.py
@@ -18,6 +18,7 @@
 
 # basicutils - a version-agnostic API for IDA Pro with some (slightly) higher level functionality
 # This is the 7.x version - see basicutils_6x for the 7.x version
+import os
 
 import ida_bytes
 import ida_funcs
@@ -48,6 +49,12 @@ def GetFunctionName(x):
 
 def GetInputFile():
 	return idc.get_root_filename()
+
+def GetIdbFile():
+    return idc.get_idb_path()
+
+def GetRootName():
+    return os.path.join(os.path.dirname(GetIdbFile()), os.path.basename(GetInputFile()))
 
 def NextFunction(x):
 	return idc.get_next_func(x)

--- a/basicutils_7x.py
+++ b/basicutils_7x.py
@@ -102,6 +102,7 @@ def ForEveryFuncInSeg( seg, fun ):
     f = start
     while (f < end):
         """print "ev: %#x" % f"""
+        print f
         fun(f)
         f=NextFunction(f)		
 		
@@ -233,7 +234,7 @@ def GetCanonicalName(f):
 def NameCanonical(f,mod_name,func_name):
     n = "%s_%s_%08x" % (mod_name,func_name,f)
     print "Renaming %s to %s\n" % (idc.get_func_name(f),n)
-    ida_name.set_name(f,n)
+    ida_name.force_name(f,n)
 
 #Put function in canonical format when it doesn't have a name, but you know the module name    
 def RenameFuncWithAddr(f,s):

--- a/cc_base.py
+++ b/cc_base.py
@@ -18,6 +18,7 @@
 
 import basicutils_7x as basicutils
 import json
+import os
 
 ## Utilities
 
@@ -71,7 +72,7 @@ def gen_mod_graph(module_list, suffix):
 			f = basicutils.NextFunction(f)
 		c+=1
 
-	root_name = basicutils.GetInputFile()
+	root_name = basicutils.GetRootName()
 	file = open(root_name + "_" + suffix + "_mod_graph.gv", "wb")
 	
 	file.write("digraph g {\n")
@@ -91,7 +92,7 @@ def gen_mod_graph(module_list, suffix):
 def gen_rename_script(module_list, suffix):
 	c=0
 
-	root_name = basicutils.GetInputFile()
+	root_name = basicutils.GetRootName()
 	file = open(root_name + "_" + suffix + "_labels.py", "wb")
 	
 	#if (IDA_VERSION < 7):
@@ -117,7 +118,7 @@ def gen_rename_script(module_list, suffix):
 def gen_map_file(module_list, suffix):
 	c=0
 
-	root_name = basicutils.GetInputFile()
+	root_name = basicutils.GetRootName()
 	file = open(root_name + "_" + suffix + "_map.map", "wb")
 	
 	while (c<len(module_list)):
@@ -133,7 +134,7 @@ def gen_map_file(module_list, suffix):
 #Write all of the results to <target>.csv - which can be opened in your favorite spreadsheet program		
 def print_results(function_list, module_list1, module_list2):
 	c=0
-	root_name = basicutils.GetInputFile()
+	root_name = basicutils.GetRootName()
 	file = open(root_name + "_cc_results.csv", "wb")
 	
 	#write header

--- a/cc_base.py
+++ b/cc_base.py
@@ -17,6 +17,14 @@
 # HAVE A NICE DAY.
 
 import basicutils_7x as basicutils
+import json
+
+## Utilities
+
+#escape_for_graphviz()
+#Return the string escaped for usage in a GraphViz file
+def escape_for_graphviz(string):
+    return json.dumps(string)
 
 ## CodeCut Basics
 ## A couple of functions for working with function and module lists and outputting results
@@ -69,7 +77,7 @@ def gen_mod_graph(module_list, suffix):
 	file.write("digraph g {\n")
 	
 	for (node1,node2) in g:
-		line = "%s -> %s\n" % (node1,node2)
+		line = "%s -> %s\n" % (escape_for_graphviz(node1),escape_for_graphviz(node2))
 		file.write(line)
 		
 	file.write("}\n")
@@ -94,7 +102,7 @@ def gen_rename_script(module_list, suffix):
 	
 	while (c<len(module_list)):
 		m=module_list[c]
-		file.write("\tbasicutils.RenameRangeWithAddr(0x%x,0x%x,\"%s\")\n"%(m.start,m.end,m.name))
+		file.write("\tbasicutils.RenameRangeWithAddr(0x%x,0x%x,%r)\n"%(m.start,m.end,m.name))
 		c+=1
 		
 	file.write("\n")


### PR DESCRIPTION
- When using strings with "quotes" in them, the code would generate invalid
  GraphViz files & renaming scripts. Strings are now escaped using `json.dumps()`
  for the GraphViz file and `repr()` for the rename scripts.
- IDA is quite strict about the characters allowed in function names. This means
  that spaces and special characters cannot be used. To go around that, we now
  use `ida_name.force_name()` to force IDA to accept the name. It will render
  underscores (`_`) instead of the special characters.
- Sometimes the executable is in a non-writable directory, but the IDB is
  always in a writable one.